### PR TITLE
Refactor Vite configuration and update server port

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,5 @@
-import react from '@vitejs/plugin-react-swc';
 import path from 'path';
+import react from '@vitejs/plugin-react-swc';
 import { defineConfig } from 'vite';
 import eslintPlugin from 'vite-plugin-eslint';
 
@@ -42,6 +42,6 @@ export default defineConfig({
 	// plugins: [react(), eslintPlugin()],
 	server: {
 		// port: 3000,
-		port: isProduction ? 4015 : 3000,
+		port: isProduction ? 4025 : 3000,
 	},
 });

--- a/web.config
+++ b/web.config
@@ -12,7 +12,7 @@
             <rules>
                 <rule name="ReverseProxyInboundRule1" stopProcessing="true">
                     <match url="(.*)" />
-                    <action type="Rewrite" url="http://192.168.10.154:4015/{R:1}" />
+                    <action type="Rewrite" url="http://192.168.10.154:4025/{R:1}" />
                 </rule>
             </rules>
         </rewrite>


### PR DESCRIPTION
Refactored the Vite configuration file to import the 'react' plugin from '@vitejs/plugin-react-swc' before the 'path' module. Additionally, updated the server port in the Vite configuration to use port 4025 instead of 4015 in production mode.

Update Reverse Proxy URL in web.config