### PR TITLE
Update DevTool import statements across components

### DIFF
--- a/src/pages/commercial/lc/add-update.jsx
+++ b/src/pages/commercial/lc/add-update.jsx
@@ -4,7 +4,6 @@ import {
 	useOtherMasterLcValueLabel,
 } from '@/state/other';
 import { useStoreLC } from '@/state/store';
-import { DevTool } from '@hookform/devtools';
 import DatePicker from 'react-datepicker';
 import { useFetchForRhfReset, useRHF } from '@/hooks';
 
@@ -12,6 +11,7 @@ import { AddModal } from '@/components/Modal';
 import { FormField, Input, ReactSelect, Textarea } from '@/ui';
 
 import nanoid from '@/lib/nanoid';
+import { DevTool } from '@lib/react-hook-devtool';
 import GetDateTime from '@/util/GetDateTime';
 import { LC_NULL, LC_SCHEMA } from '@/util/Schema';
 

--- a/src/pages/commercial/master-lc/add-update.jsx
+++ b/src/pages/commercial/master-lc/add-update.jsx
@@ -1,16 +1,24 @@
 import { useAuth } from '@/context/auth';
 import { useOtherMasterLcValueLabel } from '@/state/other';
 import { useStoreMasterLC } from '@/state/store';
-import { DevTool } from '@hookform/devtools';
 import DatePicker from 'react-datepicker';
 import { useFetchForRhfReset, useRHF } from '@/hooks';
+
+
 
 import { AddModal } from '@/components/Modal';
 import { FormField, Input, ReactSelect, Textarea } from '@/ui';
 
+
+
 import nanoid from '@/lib/nanoid';
+import { DevTool } from '@lib/react-hook-devtool';
 import GetDateTime from '@/util/GetDateTime';
 import { MASTER_LC_NULL, MASTER_LC_SCHEMA } from '@/util/Schema';
+
+
+
+
 
 export default function Index({
 	modalId = '',

--- a/src/pages/hr/department/AddOrUpdate.jsx
+++ b/src/pages/hr/department/AddOrUpdate.jsx
@@ -4,13 +4,13 @@ import {
 	useAdminDesignations,
 	useAdminUsers,
 } from '@/state/hr';
-import { DevTool } from '@hookform/devtools';
 import { useFetchForRhfReset, useRHF } from '@/hooks';
 
 import { AddModal } from '@/components/Modal';
 import { Input, Textarea } from '@/ui';
 
 import nanoid from '@/lib/nanoid';
+import { DevTool } from '@lib/react-hook-devtool';
 import GetDateTime from '@/util/GetDateTime';
 import { USER_DEPARTMENT_NULL, USER_DEPARTMENT_SCHEMA } from '@/util/Schema';
 

--- a/src/pages/hr/designation/AddOrUpdate.jsx
+++ b/src/pages/hr/designation/AddOrUpdate.jsx
@@ -1,12 +1,12 @@
 import { useAuth } from '@/context/auth';
 import { useAdminDesignations, useAdminUsers } from '@/state/hr';
-import { DevTool } from '@hookform/devtools';
 import { useFetchForRhfReset, useRHF } from '@/hooks';
 
 import { AddModal } from '@/components/Modal';
 import { Input, Textarea } from '@/ui';
 
 import nanoid from '@/lib/nanoid';
+import { DevTool } from '@lib/react-hook-devtool';
 import GetDateTime from '@/util/GetDateTime';
 import { USER_DESIGNATION_NULL, USER_DESIGNATION_SCHEMA } from '@/util/Schema';
 

--- a/src/pages/store/buyer/add-update.jsx
+++ b/src/pages/store/buyer/add-update.jsx
@@ -1,13 +1,13 @@
 import { useAuth } from '@/context/auth';
 import { useOtherBuyerValueLabel } from '@/state/other';
 import { useStoreBuyer } from '@/state/store';
-import { DevTool } from '@hookform/devtools';
 import { useFetchForRhfReset, useRHF } from '@/hooks';
 
 import { AddModal } from '@/components/Modal';
 import { Input, Textarea } from '@/ui';
 
 import nanoid from '@/lib/nanoid';
+import { DevTool } from '@lib/react-hook-devtool';
 import GetDateTime from '@/util/GetDateTime';
 import { LIBRARY_NULL, LIBRARY_SCHEMA } from '@/util/Schema';
 

--- a/src/pages/store/category/add-update.jsx
+++ b/src/pages/store/category/add-update.jsx
@@ -2,13 +2,13 @@ import { useEffect } from 'react';
 import { useAuth } from '@/context/auth';
 import { useOtherCategoryValueLabel } from '@/state/other';
 import { useStoreCategory } from '@/state/store';
-import { DevTool } from '@hookform/devtools';
 import { useFetchForRhfReset, useRHF } from '@/hooks';
 
 import { AddModal } from '@/components/Modal';
 import { FormField, Input, JoinInputSelect, ReactSelect, Textarea } from '@/ui';
 
 import nanoid from '@/lib/nanoid';
+import { DevTool } from '@lib/react-hook-devtool';
 import GetDateTime from '@/util/GetDateTime';
 import { LIBRARY_NULL, LIBRARY_SCHEMA } from '@/util/Schema';
 

--- a/src/pages/store/color/add-update.jsx
+++ b/src/pages/store/color/add-update.jsx
@@ -2,13 +2,13 @@ import { useEffect } from 'react';
 import { useAuth } from '@/context/auth';
 import { useOtherColorValueLabel } from '@/state/other';
 import { useStoreColor } from '@/state/store';
-import { DevTool } from '@hookform/devtools';
 import { useFetchForRhfReset, useRHF } from '@/hooks';
 
 import { AddModal } from '@/components/Modal';
 import { FormField, Input, JoinInputSelect, ReactSelect, Textarea } from '@/ui';
 
 import nanoid from '@/lib/nanoid';
+import { DevTool } from '@lib/react-hook-devtool';
 import GetDateTime from '@/util/GetDateTime';
 import { LIBRARY_NULL, LIBRARY_SCHEMA } from '@/util/Schema';
 
@@ -21,7 +21,7 @@ export default function Index({
 }) {
 	const { user } = useAuth();
 	const { url, updateData, postData } = useStoreColor();
-	
+
 	const { invalidateQuery: invalidateColorValueLabel } =
 		useOtherColorValueLabel();
 

--- a/src/pages/store/log/issue/add-update.jsx
+++ b/src/pages/store/log/issue/add-update.jsx
@@ -1,13 +1,13 @@
 import { useEffect } from 'react';
 import { useAuth } from '@/context/auth';
 import { useStoreBuyer, useStoreIssue, useStoreStock } from '@/state/store';
-import { DevTool } from '@hookform/devtools';
 import { useFetchForRhfReset, useRHF } from '@/hooks';
 
 import { AddModal } from '@/components/Modal';
 import { FormField, Input, JoinInputSelect, ReactSelect, Textarea } from '@/ui';
 
 import nanoid from '@/lib/nanoid';
+import { DevTool } from '@lib/react-hook-devtool';
 import GetDateTime from '@/util/GetDateTime';
 import { ISSUE_NULL, ISSUE_SCHEMA } from '@/util/Schema';
 

--- a/src/pages/store/log/receive/add-update.jsx
+++ b/src/pages/store/log/receive/add-update.jsx
@@ -14,7 +14,6 @@ import {
 	useStoreReceiveEntry,
 	useStoreStock,
 } from '@/state/store';
-import { DevTool } from '@hookform/devtools';
 import { useFetch, useFetchForRhfReset, useRHF } from '@/hooks';
 
 import { AddModal } from '@/components/Modal';
@@ -28,6 +27,7 @@ import {
 } from '@/ui';
 
 import nanoid from '@/lib/nanoid';
+import { DevTool } from '@lib/react-hook-devtool';
 import GetDateTime from '@/util/GetDateTime';
 import { RECEIVE_ENTRY_NULL, RECEIVE_ENTRY_SCHEMA } from '@/util/Schema';
 

--- a/src/pages/store/material/add-update.jsx
+++ b/src/pages/store/material/add-update.jsx
@@ -1,15 +1,14 @@
-
 import { useEffect } from 'react';
 import { useAuth } from '@/context/auth';
 import { useOtherMaterialValueLabel } from '@/state/other';
 import { useStoreMaterial } from '@/state/store';
-import { DevTool } from '@hookform/devtools';
 import { useFetchForRhfReset, useRHF } from '@/hooks';
 
 import { AddModal } from '@/components/Modal';
 import { FormField, Input, JoinInputSelect, ReactSelect, Textarea } from '@/ui';
 
 import nanoid from '@/lib/nanoid';
+import { DevTool } from '@lib/react-hook-devtool';
 import GetDateTime from '@/util/GetDateTime';
 import { LIBRARY_NULL, LIBRARY_SCHEMA } from '@/util/Schema';
 

--- a/src/pages/store/receive/entry/index.jsx
+++ b/src/pages/store/receive/entry/index.jsx
@@ -20,7 +20,7 @@ import {
 	useStoreStock,
 } from '@/state/store';
 import { useAuth } from '@context/auth';
-import { DevTool } from '@hookform/devtools';
+import { DevTool } from '@lib/react-hook-devtool';
 import { configure, HotKeys } from 'react-hotkeys';
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
 import { useAccess, useFetchForRhfReset, useRHF } from '@/hooks';

--- a/src/pages/store/size/add-update.jsx
+++ b/src/pages/store/size/add-update.jsx
@@ -2,13 +2,13 @@ import { useEffect } from 'react';
 import { useAuth } from '@/context/auth';
 import { useOtherSizeValueLabel } from '@/state/other';
 import { useStoreSize } from '@/state/store';
-import { DevTool } from '@hookform/devtools';
 import { useFetchForRhfReset, useRHF } from '@/hooks';
 
 import { AddModal } from '@/components/Modal';
 import { FormField, Input, JoinInputSelect, ReactSelect, Textarea } from '@/ui';
 
 import nanoid from '@/lib/nanoid';
+import { DevTool } from '@lib/react-hook-devtool';
 import GetDateTime from '@/util/GetDateTime';
 import { LIBRARY_NULL, LIBRARY_SCHEMA } from '@/util/Schema';
 

--- a/src/pages/store/stock/add-update.jsx
+++ b/src/pages/store/stock/add-update.jsx
@@ -8,13 +8,13 @@ import {
 	useOtherUnitValueLabel,
 } from '@/state/other';
 import { useStoreStock } from '@/state/store';
-import { DevTool } from '@hookform/devtools';
 import { useFetchForRhfReset, useRHF } from '@/hooks';
 
 import { AddModal } from '@/components/Modal';
 import { FormField, Input, ReactSelect, Textarea } from '@/ui';
 
 import nanoid from '@/lib/nanoid';
+import { DevTool } from '@lib/react-hook-devtool';
 import GetDateTime from '@/util/GetDateTime';
 import { STOCK_NULL, STOCK_SCHEMA } from '@/util/Schema';
 
@@ -265,7 +265,7 @@ export default function Index({
 						}}
 					/>
 				</FormField> */}
-				{/* <FormField label='unit' title='Unit' errors={errors}>
+			{/* <FormField label='unit' title='Unit' errors={errors}>
 					<Controller
 						name={'unit'}
 						control={control}

--- a/src/pages/store/stock/issue.jsx
+++ b/src/pages/store/stock/issue.jsx
@@ -1,12 +1,12 @@
 import { useAuth } from '@/context/auth';
 import { useStoreIssue, useStoreStock } from '@/state/store';
-import { DevTool } from '@hookform/devtools';
 import { useFetch, useRHF } from '@/hooks';
 
 import { AddModal } from '@/components/Modal';
 import { JoinInput, Textarea } from '@/ui';
 
 import nanoid from '@/lib/nanoid';
+import { DevTool } from '@lib/react-hook-devtool';
 import GetDateTime from '@/util/GetDateTime';
 import { ISSUE_NULL, ISSUE_SCHEMA } from '@/util/Schema';
 

--- a/src/pages/store/unit/add-update.jsx
+++ b/src/pages/store/unit/add-update.jsx
@@ -2,13 +2,13 @@ import { useEffect } from 'react';
 import { useAuth } from '@/context/auth';
 import { useOtherUnitValueLabel } from '@/state/other';
 import { useStoreUnit } from '@/state/store';
-import { DevTool } from '@hookform/devtools';
 import { useFetchForRhfReset, useRHF } from '@/hooks';
 
 import { AddModal } from '@/components/Modal';
 import { FormField, Input, JoinInputSelect, ReactSelect, Textarea } from '@/ui';
 
 import nanoid from '@/lib/nanoid';
+import { DevTool } from '@lib/react-hook-devtool';
 import GetDateTime from '@/util/GetDateTime';
 import { LIBRARY_NULL, LIBRARY_SCHEMA } from '@/util/Schema';
 

--- a/src/pages/store/vendor/add-update.jsx
+++ b/src/pages/store/vendor/add-update.jsx
@@ -1,13 +1,13 @@
 import { useAuth } from '@/context/auth';
 import { useOtherVendorValueLabel } from '@/state/other';
 import { useStoreVendor } from '@/state/store';
-import { DevTool } from '@hookform/devtools';
 import { useFetchForRhfReset, useRHF } from '@/hooks';
 
 import { AddModal } from '@/components/Modal';
 import { Input, Textarea } from '@/ui';
 
 import nanoid from '@/lib/nanoid';
+import { DevTool } from '@lib/react-hook-devtool';
 import GetDateTime from '@/util/GetDateTime';
 import { VENDOR_NULL, VENDOR_SCHEMA } from '@/util/Schema';
 


### PR DESCRIPTION
Refactor import statements to use the new library path for DevTool in multiple components. This change ensures consistency and aligns with the updated library structure.